### PR TITLE
`enrichError()` replaces `validateParams()`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## 2.4.0
+- *[Deprecation]* `validateParams()` will be deprecated in next major version, in favour of: `enrichError()`
+   Validation of input parameters and returned result is now responsability of mini-client & mini-service.
+   `enrichError()` ensures that Joi `ValidationError`, when thrown, get enriched and turned into consistent
+   Boom errors
+- Dependencies update
+
+## 2.3.0
+- Expose CRC32 checksum header name
+- Dependencies update
+
+## 2.2.1
+- Add extractValidate that allow validation objects in options
+- Include API name in validation errors
+- Better documentation
+
+## 2.0.0
+- Rename service to group
+- Introduce extractGroup()
+- Upgrade all deps to latests
+- Use husky instead of ghooks
+
+## 1.0.0
+- initial release

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-[![NPM Version][npm-image]][npm-url]
-[![Dependencies][david-image]][david-url]
-[![Build][travis-image]][travis-url]
-[![Test Coverage][coveralls-image]][coveralls-url]
+[![NPM Version][npm-badge]][npm-url]
+[![Dependencies][david-badge]][david-url]
+[![NSP Status][nsp-badge]][nsp-url]
+[![Build][travis-badge]][travis-url]
+[![Test Coverage][coveralls-badge]][coveralls-url]
 
 # Minimalist µServices
 
@@ -14,7 +15,7 @@ Its principles are the following:
 - hide deployment details and provide simple-yet-working solution
 - promises based
 
-All mini-* libraries use the latest ES6 features, so they requires node 6+
+All mini-* libraries use the latest ES2017 features, so they requires node 8+
 
 Please checkout the [API reference][api-reference]
 
@@ -25,37 +26,19 @@ This project was kindly sponsored by [nearForm][nearform].
 
 Copyright [Damien Simonin Feugas][feugy] and other contributors, licensed under [MIT](./LICENSE).
 
-## Changelog
-
-### 2.3.0
-- Expose CRC32 checksum header name
-- Dependencies update
-
-### 2.2.1
-- Add extractValidate that allow validation objects in options
-- Include API name in validation errors
-- Better documentation
-
-### 2.0.0
-- Rename service to group
-- Introduce extractGroup()
-- Upgrade all deps to latests
-- Use husky instead of ghooks
-
-### 1.0.0
-- initial release
-
 [nearform]: http://nearform.com
 [feugy]: https://github.com/feugy
 [mini-service-url]: https://github.com/feugy/mini-service
 [mini-client-url]: https://github.com/feugy/mini-client
-[david-image]: https://img.shields.io/david/feugy/mini-utils.svg
+[david-badge]: https://img.shields.io/david/feugy/mini-utils.svg
 [david-url]: https://david-dm.org/feugy/mini-utils
-[npm-image]: https://img.shields.io/npm/v/mini-service-utils.svg
+[npm-badge]: https://img.shields.io/npm/v/mini-service-utils.svg
 [npm-url]: https://npmjs.org/package/mini-service-utils
-[travis-image]: https://api.travis-ci.org/feugy/mini-utils.svg
+[travis-badge]: https://api.travis-ci.org/feugy/mini-utils.svg
 [travis-url]: https://travis-ci.org/feugy/mini-utils
-[coveralls-image]: https://img.shields.io/coveralls/feugy/mini-utils/master.svg
+[coveralls-badge]: https://img.shields.io/coveralls/feugy/mini-utils/master.svg
 [coveralls-url]: https://coveralls.io/r/feugy/mini-utils?branch=master
+[nsp-badge]: https://nodesecurity.io/orgs/perso/projects/6bc9b474-6f9e-4db0-a4d3-c3bf5443a63a/badge
+[nsp-url]: https://nodesecurity.io/orgs/perso/projects/6bc9b474-6f9e-4db0-a4d3-c3bf5443a63a
 [distributed-monolith]: https://www.infoq.com/news/2016/02/services-distributed-monolith
 [api-reference]: https://feugy.github.io/mini-utils/

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,7 @@
 <label for="nav-trigger" class="overlay"></label>
 
 <nav>
-    <h2><a href="index.html">Home</a></h2><h3>Modules</h3><ul><li><a href="module-index.html">index</a><ul class='methods'><li data-type='method'><a href="module-index.html#.arrayToObj">arrayToObj</a></li><li data-type='method'><a href="module-index.html#.extractGroups">extractGroups</a></li><li data-type='method'><a href="module-index.html#.extractValidate">extractValidate</a></li><li data-type='method'><a href="module-index.html#.getLogger">getLogger</a></li><li data-type='method'><a href="module-index.html#.getParamNames">getParamNames</a></li><li data-type='method'><a href="module-index.html#.isApi">isApi</a></li><li data-type='method'><a href="module-index.html#.validateParams">validateParams</a></li></ul></li></ul>
+    <h2><a href="index.html">Home</a></h2><h3>Modules</h3><ul><li><a href="module-index.html">index</a><ul class='methods'><li data-type='method'><a href="module-index.html#.arrayToObj">arrayToObj</a></li><li data-type='method'><a href="module-index.html#.enrichError">enrichError</a></li><li data-type='method'><a href="module-index.html#.extractGroups">extractGroups</a></li><li data-type='method'><a href="module-index.html#.extractValidate">extractValidate</a></li><li data-type='method'><a href="module-index.html#.getLogger">getLogger</a></li><li data-type='method'><a href="module-index.html#.getParamNames">getParamNames</a></li><li data-type='method'><a href="module-index.html#.isApi">isApi</a></li><li data-type='method'><a href="module-index.html#.validateParams">validateParams</a></li></ul></li></ul>
 </nav>
 
 <div id="main">
@@ -48,6 +48,7 @@
     <section class="readme">
         <article><p><a href="https://npmjs.org/package/mini-service-utils"><img src="https://img.shields.io/npm/v/mini-service-utils.svg" alt="NPM Version"></a>
 <a href="https://david-dm.org/feugy/mini-utils"><img src="https://img.shields.io/david/feugy/mini-utils.svg" alt="Dependencies"></a>
+<a href="https://nodesecurity.io/orgs/perso/projects/6bc9b474-6f9e-4db0-a4d3-c3bf5443a63a"><img src="https://nodesecurity.io/orgs/perso/projects/6bc9b474-6f9e-4db0-a4d3-c3bf5443a63a/badge" alt="NSP Status"></a>
 <a href="https://travis-ci.org/feugy/mini-utils"><img src="https://api.travis-ci.org/feugy/mini-utils.svg" alt="Build"></a>
 <a href="https://coveralls.io/r/feugy/mini-utils?branch=master"><img src="https://img.shields.io/coveralls/feugy/mini-utils/master.svg" alt="Test Coverage"></a></p>
 <h1>Minimalist µServices</h1><p>The goal of <a href="https://github.com/feugy/mini-service">mini-service</a> is to give the minimal structure to implement a µService, that can be invoked locally or remotely.
@@ -59,28 +60,10 @@
 <li>hide deployment details and provide simple-yet-working solution</li>
 <li>promises based</li>
 </ul>
-<p>All mini-* libraries use the latest ES6 features, so they requires node 6+</p>
+<p>All mini-* libraries use the latest ES2017 features, so they requires node 8+</p>
 <p>Please checkout the <a href="https://feugy.github.io/mini-utils/">API reference</a></p>
 <p>This project was kindly sponsored by <a href="http://nearform.com">nearForm</a>.</p>
-<h2>License</h2><p>Copyright <a href="https://github.com/feugy">Damien Simonin Feugas</a> and other contributors, licensed under <a href="./LICENSE">MIT</a>.</p>
-<h2>Changelog</h2><h3>2.3.0</h3><ul>
-<li>Expose CRC32 checksum header name</li>
-<li>Dependencies update</li>
-</ul>
-<h3>2.2.1</h3><ul>
-<li>Add extractValidate that allow validation objects in options</li>
-<li>Include API name in validation errors</li>
-<li>Better documentation</li>
-</ul>
-<h3>2.0.0</h3><ul>
-<li>Rename service to group</li>
-<li>Introduce extractGroup()</li>
-<li>Upgrade all deps to latests</li>
-<li>Use husky instead of ghooks</li>
-</ul>
-<h3>1.0.0</h3><ul>
-<li>initial release</li>
-</ul></article>
+<h2>License</h2><p>Copyright <a href="https://github.com/feugy">Damien Simonin Feugas</a> and other contributors, licensed under <a href="./LICENSE">MIT</a>.</p></article>
     </section>
 
 

--- a/docs/index.js.html
+++ b/docs/index.js.html
@@ -22,7 +22,7 @@
 <label for="nav-trigger" class="overlay"></label>
 
 <nav>
-    <h2><a href="index.html">Home</a></h2><h3>Modules</h3><ul><li><a href="module-index.html">index</a><ul class='methods'><li data-type='method'><a href="module-index.html#.arrayToObj">arrayToObj</a></li><li data-type='method'><a href="module-index.html#.extractGroups">extractGroups</a></li><li data-type='method'><a href="module-index.html#.extractValidate">extractValidate</a></li><li data-type='method'><a href="module-index.html#.getLogger">getLogger</a></li><li data-type='method'><a href="module-index.html#.getParamNames">getParamNames</a></li><li data-type='method'><a href="module-index.html#.isApi">isApi</a></li><li data-type='method'><a href="module-index.html#.validateParams">validateParams</a></li></ul></li></ul>
+    <h2><a href="index.html">Home</a></h2><h3>Modules</h3><ul><li><a href="module-index.html">index</a><ul class='methods'><li data-type='method'><a href="module-index.html#.arrayToObj">arrayToObj</a></li><li data-type='method'><a href="module-index.html#.enrichError">enrichError</a></li><li data-type='method'><a href="module-index.html#.extractGroups">extractGroups</a></li><li data-type='method'><a href="module-index.html#.extractValidate">extractValidate</a></li><li data-type='method'><a href="module-index.html#.getLogger">getLogger</a></li><li data-type='method'><a href="module-index.html#.getParamNames">getParamNames</a></li><li data-type='method'><a href="module-index.html#.isApi">isApi</a></li><li data-type='method'><a href="module-index.html#.validateParams">validateParams</a></li></ul></li></ul>
 </nav>
 
 <div id="main">
@@ -39,6 +39,7 @@
         <article>
             <pre class="prettyprint source linenums"><code>const bunyan = require('bunyan')
 const joi = require('joi')
+const {boomify} = require('boom')
 const {name} = require('../package.json')
 
 /**
@@ -126,10 +127,10 @@ exports.arrayToObj = (array, properties) => {
   }
   return obj
 }
-
 /**
  * @summary Validates some values with the given schema, with a custom error message when
  * more values than expected are provided
+ * @deprecated perform validation manually and use `enrichError()`
  * @param {Object} values     validated values, provided into a hash
  * @param {Joi} schema        Joi validation schema
  * @param {String} id         API id used in error detailed report
@@ -137,6 +138,8 @@ exports.arrayToObj = (array, properties) => {
  * @returns {Error|null}      if validation failed, the detailed error, or null if values are valid
  */
 exports.validateParams = (values, schema, id, expected) => {
+  process.emitWarning('[mini-utils] validateParams() will be deprecated in next major version. '
+    + 'Use enrichError() instead, and see https://github.com/feugy/mini-utils/blob/master/CHANGELOG.md')
   if (Object.keys(values).length > expected) {
     // too many values provided
     return new Error(`API ${id} must contain at most ${expected} parameters`)
@@ -147,6 +150,32 @@ exports.validateParams = (values, schema, id, expected) => {
     return result.error
   }
   return null
+}
+
+/**
+ * @summary Enrich validation error for a given API, with friendly message
+ * @description When enriching validation error for
+ * - input parameters, a 400 (Bad Request) Boom error is returned
+ * - returned results, a 512 (Bad Response) Boom error is returned
+ *
+ * @param {ValidationError} err       Joi validation error, or null
+ * @param {String} id                 API id used in error detailed report
+ * @param {Boomean} [forInput = true] true when enriching error for input parameters,
+ *                                    false for returned result
+ * @returns {Error|null}              the enriched detailed error, or null err was so
+ */
+exports.enrichError = (err, id, forInput = true) => {
+  if (!err) {
+    return null
+  }
+  // customize error message for convenience
+  err.message = `Incorrect ${forInput ? 'parameters' : 'response'} for API ${id}: ${err.message}`
+  const error = boomify(err, {statusCode: forInput ? 400 : 512})
+  if (!forInput) {
+    error.output.payload.error = 'Bad Response'
+  }
+
+  return error
 }
 
 /**
@@ -196,18 +225,19 @@ exports.extractGroups = opts => {
 
 /**
  * @summary Extract validation objects for a given API
- * @description Each exposed API can have a Joi object assigned to validate received parameters
+ * @description Each exposed API can have a Joi object assigned to validate received parameters/response
  * This validation object can be either:
- * - in the `validate` property of the API function
- * - in the `validate` property of the API group options
+ * - in the clause property of the API function
+ * - in the clause property of the API group options
  * @param {String} id       name of the exposed API for which validation object is researched
  * @param {Object} apis     hash containing the exposed API function
  * @param {Object} opts     options that may contains validation hash
  * @param {Object} [opts.validate]  May contains validation object for the exposed API
+ * @param {String} [clause = 'validate']  name of the searched clause, defaults to 'validate'
  * @return {Joi|null}       validation object found, or null
  */
-exports.extractValidate = (id, apis, opts) =>
-  apis[id].validate || opts &amp;&amp; opts.validate || null
+exports.extractValidate = (id, apis, opts, clause = 'validate') =>
+  apis[id][clause] || opts &amp;&amp; opts[clause] || null
 
 /**
  * HTTP header name used in response to exchange exposed API checksum.

--- a/docs/module-index.html
+++ b/docs/module-index.html
@@ -22,7 +22,7 @@
 <label for="nav-trigger" class="overlay"></label>
 
 <nav>
-    <h2><a href="index.html">Home</a></h2><h3>Modules</h3><ul><li><a href="module-index.html">index</a><ul class='methods'><li data-type='method'><a href="module-index.html#.arrayToObj">arrayToObj</a></li><li data-type='method'><a href="module-index.html#.extractGroups">extractGroups</a></li><li data-type='method'><a href="module-index.html#.extractValidate">extractValidate</a></li><li data-type='method'><a href="module-index.html#.getLogger">getLogger</a></li><li data-type='method'><a href="module-index.html#.getParamNames">getParamNames</a></li><li data-type='method'><a href="module-index.html#.isApi">isApi</a></li><li data-type='method'><a href="module-index.html#.validateParams">validateParams</a></li></ul></li></ul>
+    <h2><a href="index.html">Home</a></h2><h3>Modules</h3><ul><li><a href="module-index.html">index</a><ul class='methods'><li data-type='method'><a href="module-index.html#.arrayToObj">arrayToObj</a></li><li data-type='method'><a href="module-index.html#.enrichError">enrichError</a></li><li data-type='method'><a href="module-index.html#.extractGroups">extractGroups</a></li><li data-type='method'><a href="module-index.html#.extractValidate">extractValidate</a></li><li data-type='method'><a href="module-index.html#.getLogger">getLogger</a></li><li data-type='method'><a href="module-index.html#.getParamNames">getParamNames</a></li><li data-type='method'><a href="module-index.html#.isApi">isApi</a></li><li data-type='method'><a href="module-index.html#.validateParams">validateParams</a></li></ul></li></ul>
 </nav>
 
 <div id="main">
@@ -63,7 +63,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line5">line 5</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line6">line 6</a>
     </li></ul></dd>
     
 
@@ -158,7 +158,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line177">line 177</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line207">line 207</a>
     </li></ul></dd>
     
 
@@ -234,7 +234,7 @@ Will contain the CRC-32 checksum of the <code>JSON.stringify(exposed.apis)</code
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line78">line 78</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line79">line 79</a>
     </li></ul></dd>
     
 
@@ -403,6 +403,261 @@ with corresponding values from <code>array</code></p>
 
     
 
+    <h4 class="name" id=".enrichError"><span class="type-signature">(static) </span>enrichError<span class="signature">(err, id, forInput<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {Error|null}</span></h4>
+
+    
+    <p class="summary"><p>Enrich validation error for a given API, with friendly message</p></p>
+    
+
+
+
+
+<dl class="details">
+
+    
+    <dt class="tag-source">Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line128">line 128</a>
+    </li></ul></dd>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+</dl>
+
+
+
+
+
+<div class="description">
+    <p>When enriching validation error for</p>
+<ul>
+<li>input parameters, a 400 (Bad Request) Boom error is returned</li>
+<li>returned results, a 512 (Bad Response) Boom error is returned</li>
+</ul>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+    <h5>Parameters:</h5>
+    
+
+<table class="params">
+    <thead>
+    <tr>
+        
+        <th>Name</th>
+        
+
+        <th>Type</th>
+
+        
+        <th>Attributes</th>
+        
+
+        
+        <th>Default</th>
+        
+
+        <th class="last">Description</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+
+        <tr>
+            
+                <td class="name"><code>err</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">ValidationError</span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                </td>
+            
+
+            <td class="description last"><p>Joi validation error, or null</p></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>id</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">String</span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                </td>
+            
+
+            <td class="description last"><p>API id used in error detailed report</p></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>forInput</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">Boomean</span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+                    &lt;optional><br>
+                
+
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                    <code>true</code>
+                
+                </td>
+            
+
+            <td class="description last"><p>true when enriching error for input parameters,
+                                   false for returned result</p></td>
+        </tr>
+
+    
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h5>Returns:</h5>
+
+        
+<div class="param-desc">
+    <p>the enriched detailed error, or null err was so</p>
+</div>
+
+
+
+<dl class="param-type">
+    <dt>
+        Type
+    </dt>
+    <dd>
+        
+<span class="param-type">Error</span>
+|
+
+<span class="param-type">null</span>
+
+
+    </dd>
+</dl>
+
+    
+
+
+        
+            
+
+    
+
     <h4 class="name" id=".extractGroups"><span class="type-signature">(static) </span>extractGroups<span class="signature">(opts)</span><span class="type-signature"> &rarr; {ExtractionResult}</span></h4>
 
     
@@ -417,7 +672,7 @@ with corresponding values from <code>array</code></p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line140">line 140</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line169">line 169</a>
     </li></ul></dd>
     
 
@@ -562,7 +817,7 @@ The specify parameter could be the group itself, mixed with the options</p>
 
     
 
-    <h4 class="name" id=".extractValidate"><span class="type-signature">(static) </span>extractValidate<span class="signature">(id, apis, opts)</span><span class="type-signature"> &rarr; {Joi|null}</span></h4>
+    <h4 class="name" id=".extractValidate"><span class="type-signature">(static) </span>extractValidate<span class="signature">(id, apis, opts, clause<span class="signature-attributes">opt</span>)</span><span class="type-signature"> &rarr; {Joi|null}</span></h4>
 
     
     <p class="summary"><p>Extract validation objects for a given API</p></p>
@@ -576,7 +831,7 @@ The specify parameter could be the group itself, mixed with the options</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line170">line 170</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line200">line 200</a>
     </li></ul></dd>
     
 
@@ -616,11 +871,11 @@ The specify parameter could be the group itself, mixed with the options</p>
 
 
 <div class="description">
-    <p>Each exposed API can have a Joi object assigned to validate received parameters
+    <p>Each exposed API can have a Joi object assigned to validate received parameters/response
 This validation object can be either:</p>
 <ul>
-<li>in the <code>validate</code> property of the API function</li>
-<li>in the <code>validate</code> property of the API group options</li>
+<li>in the clause property of the API function</li>
+<li>in the clause property of the API group options</li>
 </ul>
 </div>
 
@@ -647,7 +902,11 @@ This validation object can be either:</p>
         <th>Type</th>
 
         
+        <th>Attributes</th>
+        
 
+        
+        <th>Default</th>
         
 
         <th class="last">Description</th>
@@ -672,7 +931,19 @@ This validation object can be either:</p>
             </td>
 
             
+                <td class="attributes">
+                
 
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                </td>
             
 
             <td class="description last"><p>name of the exposed API for which validation object is researched</p></td>
@@ -695,7 +966,19 @@ This validation object can be either:</p>
             </td>
 
             
+                <td class="attributes">
+                
 
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                </td>
             
 
             <td class="description last"><p>hash containing the exposed API function</p></td>
@@ -718,7 +1001,19 @@ This validation object can be either:</p>
             </td>
 
             
+                <td class="attributes">
+                
 
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                </td>
             
 
             <td class="description last"><p>options that may contains validation hash</p>
@@ -786,6 +1081,45 @@ This validation object can be either:</p>
         </tr>
 
     
+
+        <tr>
+            
+                <td class="name"><code>clause</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">String</span>
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+                    &lt;optional><br>
+                
+
+                
+
+                
+                </td>
+            
+
+            
+                <td class="default">
+                
+                    <code>'validate'</code>
+                
+                </td>
+            
+
+            <td class="description last"><p>name of the searched clause, defaults to 'validate'</p></td>
+        </tr>
+
+    
     </tbody>
 </table>
 
@@ -848,7 +1182,7 @@ This validation object can be either:</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line18">line 18</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line19">line 19</a>
     </li></ul></dd>
     
 
@@ -1021,7 +1355,7 @@ This validation object can be either:</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line44">line 44</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line45">line 45</a>
     </li></ul></dd>
     
 
@@ -1213,7 +1547,7 @@ This validation object can be either:</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line118">line 118</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line147">line 147</a>
     </li></ul></dd>
     
 
@@ -1367,7 +1701,7 @@ more values than expected are provided</p></p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line100">line 100</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line101">line 101</a>
     </li></ul></dd>
     
 
@@ -1385,6 +1719,8 @@ more values than expected are provided</p></p>
 
     
 
+    
+        <dt class="important tag-deprecated">Deprecated:</dt><dd><ul class="dummy"><li>perform validation manually and use `enrichError()`</li></ul></dd>
     
 
     
@@ -1592,7 +1928,7 @@ more values than expected are provided</p></p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="index.js.html">index.js</a>, <a href="index.js.html#line126">line 126</a>
+        <a href="index.js.html">index.js</a>, <a href="index.js.html#line155">line 155</a>
     </li></ul></dd>
     
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const bunyan = require('bunyan')
 const joi = require('joi')
+const {boomify} = require('boom')
 const {name} = require('../package.json')
 
 /**
@@ -87,10 +88,10 @@ exports.arrayToObj = (array, properties) => {
   }
   return obj
 }
-
 /**
  * @summary Validates some values with the given schema, with a custom error message when
  * more values than expected are provided
+ * @deprecated perform validation manually and use `enrichError()`
  * @param {Object} values     validated values, provided into a hash
  * @param {Joi} schema        Joi validation schema
  * @param {String} id         API id used in error detailed report
@@ -98,6 +99,8 @@ exports.arrayToObj = (array, properties) => {
  * @returns {Error|null}      if validation failed, the detailed error, or null if values are valid
  */
 exports.validateParams = (values, schema, id, expected) => {
+  process.emitWarning('[mini-utils] validateParams() will be deprecated in next major version. '
+    + 'Use enrichError() instead, and see https://github.com/feugy/mini-utils/blob/master/CHANGELOG.md')
   if (Object.keys(values).length > expected) {
     // too many values provided
     return new Error(`API ${id} must contain at most ${expected} parameters`)
@@ -108,6 +111,32 @@ exports.validateParams = (values, schema, id, expected) => {
     return result.error
   }
   return null
+}
+
+/**
+ * @summary Enrich validation error for a given API, with friendly message
+ * @description When enriching validation error for
+ * - input parameters, a 400 (Bad Request) Boom error is returned
+ * - returned results, a 512 (Bad Response) Boom error is returned
+ *
+ * @param {ValidationError} err       Joi validation error, or null
+ * @param {String} id                 API id used in error detailed report
+ * @param {Boomean} [forInput = true] true when enriching error for input parameters,
+ *                                    false for returned result
+ * @returns {Error|null}              the enriched detailed error, or null err was so
+ */
+exports.enrichError = (err, id, forInput = true) => {
+  if (!err) {
+    return null
+  }
+  // customize error message for convenience
+  err.message = `Incorrect ${forInput ? 'parameters' : 'response'} for API ${id}: ${err.message}`
+  const error = boomify(err, {statusCode: forInput ? 400 : 512})
+  if (!forInput) {
+    error.output.payload.error = 'Bad Response'
+  }
+
+  return error
 }
 
 /**
@@ -157,18 +186,19 @@ exports.extractGroups = opts => {
 
 /**
  * @summary Extract validation objects for a given API
- * @description Each exposed API can have a Joi object assigned to validate received parameters
+ * @description Each exposed API can have a Joi object assigned to validate received parameters/response
  * This validation object can be either:
- * - in the `validate` property of the API function
- * - in the `validate` property of the API group options
+ * - in the clause property of the API function
+ * - in the clause property of the API group options
  * @param {String} id       name of the exposed API for which validation object is researched
  * @param {Object} apis     hash containing the exposed API function
  * @param {Object} opts     options that may contains validation hash
  * @param {Object} [opts.validate]  May contains validation object for the exposed API
+ * @param {String} [clause = 'validate']  name of the searched clause, defaults to 'validate'
  * @return {Joi|null}       validation object found, or null
  */
-exports.extractValidate = (id, apis, opts) =>
-  apis[id].validate || opts && opts.validate || null
+exports.extractValidate = (id, apis, opts, clause = 'validate') =>
+  apis[id][clause] || opts && opts[clause] || null
 
 /**
  * HTTP header name used in response to exchange exposed API checksum.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-service-utils",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Shared utilities mini-* libraries: Micro services done simply",
   "author": "feugy <damien.feugas@gmail.com>",
   "license": "MIT",
@@ -20,21 +20,22 @@
     "watch-doc": "watch \"npm run doc\" ./lib"
   },
   "dependencies": {
+    "boom": "~7.1.1",
     "bunyan": "~2.0.2",
-    "joi": "~11.0.3"
+    "joi": "~13.1.1"
   },
   "devDependencies": {
-    "coveralls": "~2.13.1",
+    "coveralls": "~3.0.0",
     "docdash": "~0.4.0",
-    "eslint": "~4.7.2",
+    "eslint": "~4.16.0",
     "husky": "~0.14.3",
     "jsdoc": "~3.5.5",
-    "lab": "~14.3.1",
-    "lab-espower-transformer": "~1.1.0",
-    "next-update": "~3.5.3",
-    "nsp": "~2.8.0",
+    "lab": "~15.2.0",
+    "lab-espower-transformer": "~2.0.0",
+    "next-update": "~3.6.0",
+    "nsp": "~2.8.1",
     "power-assert": "~1.4.4",
-    "rewire": "~2.5.2",
+    "rewire": "~3.0.2",
     "watch": "~1.0.2"
   }
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,6 @@
 const Lab = require('lab')
 const Joi = require('joi')
+const {badRequest} = require('boom')
 const assert = require('power-assert')
 const rewire = require('rewire')
 const utils = rewire('../')
@@ -14,7 +15,7 @@ describe('Utilities', () => {
 
   describe('extractValidate', () => {
 
-    it('should extract from api.validate', done => {
+    it('should extract from api.validate', () => {
       const id = 'test'
       const apis = {
         [id]: () => {}
@@ -22,328 +23,345 @@ describe('Utilities', () => {
       const validation = Joi.array()
       apis[id].validate = validation
       assert.deepStrictEqual(utils.extractValidate(id, apis), validation)
-      done()
     })
 
-    it('should extract from opts.validate', done => {
+    it('should extract another clause from api', () => {
+      const id = 'test5'
+      const apis = {
+        [id]: () => {}
+      }
+      const validation = Joi.array()
+      apis[id].responseSchema = validation
+      assert.deepStrictEqual(utils.extractValidate(id, apis, {}, 'responseSchema'), validation)
+    })
+
+    it('should extract from opts.validate', () => {
       const id = 'test2'
       const apis = {
         [id]: () => {}
       }
       const validation = Joi.array()
       assert.deepStrictEqual(utils.extractValidate(id, apis, {validate: validation}), validation)
-      done()
     })
 
-    it('should not fail on missing validate key', done => {
+    it('should extract another clause from opts', () => {
+      const id = 'test6'
+      const apis = {
+        [id]: () => {}
+      }
+      const validation = Joi.array()
+      assert.deepStrictEqual(
+        utils.extractValidate(id, apis, {responseSchema: validation}, 'responseSchema'),
+        validation
+      )
+    })
+
+    it('should not fail on missing validate key', () => {
       const id = 'test3'
       const apis = {
         [id]: () => {}
       }
       assert.strictEqual(utils.extractValidate(id, apis, {}), null)
-      done()
     })
 
-    it('should not fail on missing options', done => {
+    it('should not fail on missing options', () => {
       const id = 'test4'
       const apis = {
         [id]: () => {}
       }
       assert.strictEqual(utils.extractValidate(id, apis), null)
-      done()
     })
   })
 
   describe('getLogger', () => {
 
-    beforeEach(done => {
+    beforeEach(() => {
       utils.__set__('logger', null)
-      done()
     })
 
-    it('should create a bunyan logger', done => {
+    it('should create a bunyan logger', () => {
       const logger = utils.getLogger()
       assert(logger)
       assert(logger.debug)
       assert.equal(logger.fields.name, 'mini-service-utils')
-      done()
     })
 
-    it('should reuse the same instance', done => {
+    it('should reuse the same instance', () => {
       assert.strictEqual(utils.getLogger(), utils.getLogger())
-      done()
     })
 
-    it('should be customizable', done => {
+    it('should be customizable', () => {
       const logger = utils.getLogger({name: 'toto'})
       assert(logger)
       assert(logger.debug)
       assert.equal(logger.fields.name, 'toto')
-      done()
     })
   })
 
   describe('arrayToObj', () => {
 
-    it('should transform an array to an object', done => {
+    it('should transform an array to an object', () => {
       assert.deepStrictEqual(utils.arrayToObj([1, 2], ['count', 'other']), {count: 1, other: 2})
-      done()
     })
 
-    it('should keep unexpected items in result', done => {
+    it('should keep unexpected items in result', () => {
       assert.deepStrictEqual(utils.arrayToObj([1, 2, 3, 'haha'], ['count', 'other']), {
         count: 1,
         other: 2,
         2: 3,
         3: 'haha'
       })
-      done()
     })
   })
 
   describe('isApi', () => {
 
-    it('should allow empty object', done => {
+    it('should allow empty object', () => {
       assert(utils.isApi({}))
-      done()
     })
 
-    it('should allow plain object', done => {
+    it('should allow plain object', () => {
       assert(utils.isApi({method: () => {}, attribute: 1}))
-      done()
     })
 
-    it('should allow class instances', done => {
+    it('should allow class instances', () => {
       class Service {
         method() {}
       }
       assert(utils.isApi(new Service()))
-      done()
     })
 
-    it('should not allow falsy values', done => {
+    it('should not allow falsy values', () => {
       assert.equal(utils.isApi(), false)
       assert.equal(utils.isApi(null), false)
       assert.equal(utils.isApi(''), false)
       assert.equal(utils.isApi(false), false)
       assert.equal(utils.isApi(0), false)
-      done()
     })
 
-    it('should not allow string and numbers values', done => {
+    it('should not allow string and numbers values', () => {
       assert.equal(utils.isApi('hi'), false)
       assert.equal(utils.isApi(10), false)
-      done()
     })
 
-    it('should not allow arrays', done => {
+    it('should not allow arrays', () => {
       assert.equal(utils.isApi([]), false)
       assert.equal(utils.isApi([1, 2]), false)
-      done()
     })
   })
 
-  describe('validateParams', () => {
+  describe('validateParams - soon deprecated', () => {
 
-    it('should fails when giving more parameters than expexted', done => {
+    it('should fails when giving more parameters than expexted', () => {
       const error = utils.validateParams({count: 1, other: 2}, Joi.object(), 'test', 1)
       assert(error)
       assert.equal(error.message, 'API test must contain at most 1 parameters')
-      done()
     })
 
-    it('should report validation errors', done => {
+    it('should report validation errors', () => {
       const error = utils.validateParams({count: 1}, Joi.object({other: Joi.string().required()}), 'test', 1)
       assert(error)
       assert(error.message.includes('API test'))
       assert(error.message.includes('"other" is required]'))
-      done()
     })
 
-    it('should allow valid invokations', done => {
+    it('should allow valid invokations', () => {
       const error = utils.validateParams({count: 1}, Joi.object({count: Joi.number().required()}), 'test', 1)
       assert.strictEqual(error, null)
-      done()
+    })
+  })
+
+  describe('enrichError', () => {
+
+    const validationError = Joi.object({other: Joi.string().required()}).validate({count: 1}).error
+
+    it('should return null if no error', () => {
+      assert(utils.enrichError(null, '') === null)
+    })
+
+    it('should return bad request on input validation error', () => {
+      const error = utils.enrichError(validationError, 'test-input')
+      assert(error.isBoom)
+      assert(error.output.payload.statusCode === 400)
+      assert(error.output.payload.error === 'Bad Request')
+      assert(error.message.includes('Incorrect parameters for API test-input'))
+      assert(error.message.includes('"other" is required]'))
+    })
+
+    it('should return bad response on result validation error', () => {
+      const error = utils.enrichError(validationError, 'test-response', false)
+      assert(error.isBoom)
+      assert(error.output.payload.statusCode === 512)
+      assert(error.output.payload.error === 'Bad Response')
+      assert(error.message.includes('Incorrect response for API test-response'))
+      assert(error.message.includes('"other" is required]'))
+    })
+
+    it('should override boom error', () => {
+      const error = utils.enrichError(badRequest(validationError), 'test-override', false)
+      assert(error.isBoom)
+      assert(error.output.payload.statusCode === 512)
+      assert(error.output.payload.error === 'Bad Response')
+      assert(error.message.includes('Incorrect response for API test-override'))
+      assert(error.message.includes('"other" is required]'))
     })
   })
 
   describe('getParamNames', () => {
 
-    it('should fails on null', done => {
+    it('should fails on null', () => {
       assert.throws(() => utils.getParamNames(null), /unsupported function null/)
-      done()
     })
 
-    it('should fails on undefined', done => {
+    it('should fails on undefined', () => {
       assert.throws(() => utils.getParamNames(), /unsupported function undefined/)
-      done()
     })
 
-    it('should fails on object', done => {
+    it('should fails on object', () => {
       assert.throws(() => utils.getParamNames({}), /unsupported function \[object Object\]/)
-      done()
     })
 
-    it('should fails on rest parameter', done => {
+    it('should fails on rest parameter', () => {
       assert.throws(() => utils.getParamNames((...args) => {}), /unsupported function \(\.\.\.args\)/)
-      done()
     })
 
-    it('should handle typical function', done => {
+    it('should handle typical function', () => {
       const obj = {
         ping() {
           return Promise.resolve({time: new Date()})
         }
       }
       assert.deepStrictEqual(utils.getParamNames(obj.ping), [])
-      done()
     })
 
-    it('should handle empty function declaration', done => {
+    it('should handle empty function declaration', () => {
       /* eslint prefer-arrow-callback: 0 */
       function declared() {
         noop()
       }
       assert.deepStrictEqual(utils.getParamNames(declared), [])
-      done()
     })
 
-    it('should handle empty anonymous function', done => {
+    it('should handle empty anonymous function', () => {
       /* eslint prefer-arrow-callback: 0 */
       assert.deepStrictEqual(utils.getParamNames(function() {
         noop()
       }), [])
-      done()
     })
 
-    it('should handle named function', done => {
+    it('should handle named function', () => {
       /* eslint prefer-arrow-callback: 0 */
       assert.deepStrictEqual(utils.getParamNames(function named() {
         noop()
       }), [])
-      done()
     })
 
-    it('should handle empty arrow function', done => {
+    it('should handle empty arrow function', () => {
       assert.deepStrictEqual(utils.getParamNames(() => {
         noop()
       }), [])
-      done()
     })
 
-    it('should handle function declaration with single parameter', done => {
+    it('should handle function declaration with single parameter', () => {
       /* eslint prefer-arrow-callback: 0 */
       function declared(a) {
         noop()
       }
       assert.deepStrictEqual(utils.getParamNames(declared), ['a'])
-      done()
     })
 
-    it('should handle anonymous function with single parameter', done => {
+    it('should handle anonymous function with single parameter', () => {
       /* eslint prefer-arrow-callback: 0,  no-unused-vars:0 */
       assert.deepStrictEqual(utils.getParamNames(function(a) {
         noop()
       }), ['a'])
-      done()
     })
 
-    it('should handle named function with single parameter', done => {
+    it('should handle named function with single parameter', () => {
       /* eslint prefer-arrow-callback: 0, no-unused-vars:0 */
       assert.deepStrictEqual(utils.getParamNames(function named(a) {
         noop()
       }), ['a'])
-      done()
     })
 
-    it('should handle empty arrow function with single parameter', done => {
+    it('should handle empty arrow function with single parameter', () => {
       /* eslint no-unused-vars:0 */
       assert.deepStrictEqual(utils.getParamNames(a => {
         noop()
       }), ['a'])
-      done()
     })
 
-    it('should handle function declaration with multiple parameter', done => {
+    it('should handle function declaration with multiple parameter', () => {
       /* eslint prefer-arrow-callback: 0 */
       function declared(a, b, c) {
         noop()
       }
       assert.deepStrictEqual(utils.getParamNames(declared), ['a', 'b', 'c'])
-      done()
     })
 
-    it('should handle anonymous function with multiple parameters', done => {
+    it('should handle anonymous function with multiple parameters', () => {
       /* eslint prefer-arrow-callback: 0, no-unused-vars:0 */
       assert.deepStrictEqual(utils.getParamNames(function(a, b, c) {
         noop()
       }), ['a', 'b', 'c'])
-      done()
     })
 
-    it('should handle named function with multiple parameters', done => {
+    it('should handle named function with multiple parameters', () => {
       /* eslint prefer-arrow-callback: 0, no-unused-vars:0 */
       assert.deepStrictEqual(utils.getParamNames(function named(a, b, c) {
         noop()
       }), ['a', 'b', 'c'])
-      done()
     })
 
-    it('should handle empty arrow function with multiple parameters', done => {
+    it('should handle empty arrow function with multiple parameters', () => {
       /* eslint no-unused-vars:0 */
       assert.deepStrictEqual(utils.getParamNames((a, b, c) => {
         noop()
       }), ['a', 'b', 'c'])
-      done()
     })
 
-    it('should handle function declaration with default values', done => {
+    it('should handle function declaration with default values', () => {
       /* eslint prefer-arrow-callback: 0 */
       function declared(a, b, c = false) {
         noop()
       }
       assert.deepStrictEqual(utils.getParamNames(declared), ['a', 'b', 'c'])
-      done()
     })
 
-    it('should handle anonymous function with default values', done => {
+    it('should handle anonymous function with default values', () => {
       /* eslint prefer-arrow-callback: 0, no-unused-vars:0 */
       assert.deepStrictEqual(utils.getParamNames(function(a, b, c = 10) {
         noop()
       }), ['a', 'b', 'c'])
-      done()
     })
 
-    it('should handle named function with default values', done => {
+    it('should handle named function with default values', () => {
       /* eslint prefer-arrow-callback: 0, no-unused-vars:0 */
       assert.deepStrictEqual(utils.getParamNames(function named(a, b, c = null) {
         noop()
       }), ['a', 'b', 'c'])
-      done()
     })
 
-    it('should handle empty arrow function with default values', done => {
+    it('should handle empty arrow function with default values', () => {
       /* eslint no-unused-vars:0 */
       assert.deepStrictEqual(utils.getParamNames((a, b, c = []) => {
         noop()
       }), ['a', 'b', 'c'])
-      done()
     })
   })
 
   describe('extractGroups', () => {
 
-    it('should get group from parameters', done => {
+    it('should get group from parameters', () => {
       const name = 'test'
       const init = noop
       assert.deepStrictEqual(utils.extractGroups({name, init}), {
         groups: [{name, init}],
         groupOpts: {[name]: {name, init}}
       })
-      done()
     })
 
-    it('should get groups from property', done => {
+    it('should get groups from property', () => {
       const name1 = 'test1'
       const init1 = noop
       const name2 = 'test2'
@@ -354,10 +372,9 @@ describe('Utilities', () => {
         groups: [{name: name1, init: init1}, {name: name1, init: init1}],
         groupOpts: {}
       })
-      done()
     })
 
-    it('should get group options from property', done => {
+    it('should get group options from property', () => {
       const name1 = 'test1'
       const init1 = noop
       const name2 = 'test2'
@@ -369,17 +386,14 @@ describe('Utilities', () => {
         groups: [{name: name1, init: init1}, {name: name1, init: init1}],
         groupOpts: {[name1]: {name: name1}, [name2]: {name: name2}}
       })
-      done()
     })
 
-    it('should fail if no group found', done => {
+    it('should fail if no group found', () => {
       assert.throws(() => utils.extractGroups({name: 'test'}), /No APIs nor APIs groups defined/)
-      done()
     })
 
-    it('should fail on invalid group found', done => {
+    it('should fail on invalid group found', () => {
       assert.throws(() => utils.extractGroups({groups: ['not a group']}), /Group definition at position 0/)
-      done()
     })
   })
 })


### PR DESCRIPTION
- _[Deprecation]_ `validateParams()` will be deprecated in next major version, in favour of `enrichError()`.
  
   Validation of input parameters and returned result is now responsibility of mini-client & mini-service.
   `enrichError()` ensures that Joi `ValidationError`, when thrown, get enriched and turned into consistent Boom errors.
- Dependencies update
- Dedicated CHANGELOG.md file