### PR TITLE
3.0.1: fix getParamNames to support destructuration and default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.1
+- Fix `getParamNames()` to support destructured parameters with default values
+
 ## 3.0.0
 - **[Breaking change]** `getParamNames()` supports rest parameters:
    ```js

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,8 @@ const extractParamName = (node, index) => {
     case 'AssignmentPattern':
     case 'AssignmentExpression': // eslint-disable-line no-fallthrough
       // parameter with default values
-      return node.left.name
+      // might be a destructured parameter
+      return node.left.type ? extractParamName(node.left, index) : node.left.name
     case 'RestElement':
     case 'SpreadElement': // eslint-disable-line no-fallthrough
       // rest parameter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-service-utils",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Shared utilities mini-* libraries: Micro services done simply",
   "author": "feugy <damien.feugas@gmail.com>",
   "license": "MIT",

--- a/test/utils.js
+++ b/test/utils.js
@@ -482,13 +482,13 @@ describe('Utilities', () => {
         name: 'async function shortcut',
         code: () => {
           const obj = {
-            async named (a, {b}, c) {}
+            async named (a, {b} = {}, c) {}
           }
           return obj.named
         }
       }, {
         name: 'arrow function',
-        code: () => (a, {b}, c) => {}
+        code: () => (a, [b] = [], c) => {}
       }, {
         name: 'async arrow function',
         code: () => async (a, {b}, c) => {}


### PR DESCRIPTION
With version 3.0.0, `([a] = []) => {}` was supported, but no parameter name would have been generated.